### PR TITLE
Write individual files when updated

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 var relative = require('path').relative;
 var fs       = require('fs');
+var path     = require('path');
 
 var utf8     = require('is-utf8');
 var front    = require('front-matter');
@@ -37,10 +38,17 @@ var rebuilder = function ( metalsmith ) {
       // Rerun the plugin-chain only for this one file.
       metalsmith.ware.run(files, metalsmith, function(err){
         if ( err ) { throw err; }
-        metalsmith.write(files, function(err){
-          if ( err ) { throw err; }
-          console.log ( chalk.green( '...rebuild' ) );
-        });
+
+        // metalsmith deletes the output directory when writing files, so we
+        // need to write the file outselves
+        for( var file in files ) {
+          var data = files[file];
+          var out = path.join(metalsmith.destination(), file);
+          return fs.writeFile(out, data.contents, function(err) {
+            if ( err ) { throw err; }
+            console.log ( chalk.green( '...rebuild' ) );
+          });
+        }
       });
     });
   };


### PR DESCRIPTION
Metalsmith now deletes the entire output directory as of segmentio/metalsmith@15d43a77734067f2f958ad198884d06dde5ac15f, so this change restores the ability to update an individual file when it changes without rebuilding everything. Since Metalsmith doesn't have a public method for writing each file, the plugin has to handle that as well.
