### PR TITLE
update for metalsmith 1.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,9 +5,6 @@ var resolve = require('path').resolve;
 var fs       = require('fs');
 var path     = require('path');
 
-var utf8     = require('is-utf8');
-var front    = require('front-matter');
-
 var Gaze  = require('gaze').Gaze;
 var chalk = require('chalk');
 
@@ -26,37 +23,22 @@ var watching = {};
  */
 var rebuilder = function ( metalsmith, livereload ) {
   return function(filepath, name){
-    // metalsmith isn't exposing the `read()` function
-    // reimplement it on our own.
-    fs.readFile(filepath, function(err, buffer){
-      var files = {};
-      files[name] = { contents : buffer };
+    metalsmith.readFile(filepath, function(err, file) {
+      if (err) { throw err; }
 
-      if ( utf8(buffer) ){
-        var parsed = front(buffer.toString());
-        files[name] = parsed.attributes;
-        files[name].contents = new Buffer(parsed.body);
-      }
+      var files = {};
+      files[name] = file;
 
       // Rerun the plugin-chain only for this one file.
-      metalsmith.ware.run(files, metalsmith, function(err){
+      metalsmith.run(files, function(err, files){
         if ( err ) { throw err; }
 
-        // metalsmith deletes the output directory when writing files, so we
-        // need to write the file outselves
-        for( var file in files ) {
-          var data = files[file];
-          var out = path.join(metalsmith.destination(), file);
-          fs.writeFile(out, data.contents, function(err) {
-            if ( err ) { throw err; }
-            console.log ( chalk.green( '...rebuild' ) );
-          });
-        }
-
-        if ( livereload !== null) {
-          livereload.changed({body:{files:Object.keys(files)}});
-        }
-
+        // Write the changed files
+        metalsmith.write(files, function(err){
+          if ( livereload !== null) {
+            livereload.changed({body:{files:Object.keys(files)}});
+          }
+        });
       });
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-watch",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "metalsmith watch plugin, trigger rebuilds on file change",
   "main": "lib/index.js",
   "scripts": {
@@ -12,13 +12,11 @@
   "dependencies": {
     "gaze": "^0.5.1",
     "chalk": "^0.4.0",
-    "is-utf8": "^0.2.0",
-    "front-matter": "^0.2.0",
     "tiny-lr-fork": "0.0.5",
     "lodash": "^2.4.1"
   },
   "devDependencies": {
-    "metalsmith": "^0.6.1",
+    "metalsmith": "^1.0.0",
     "mocha": "^1.17.1",
     "assert": "^1.1.1",
     "rimraf": "^2.2.6",


### PR DESCRIPTION
I was seeing some built files not respond to source file changes, possibly due to some internal caching in some other plugin.

I was able to fix this by replacing the filesystem calls in `metalsmith-watch` with the `metalsmith.readFile` and `metalsmith.write` functions which have been exposed recently.
