### PR TITLE
Update gaze to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "chalk": "^1.0.0",
-    "gaze": "^0.5.1",
+    "gaze": "^1.0.0",
     "metalsmith-filenames": "^1.0.0",
     "multimatch": "^2.0.0",
     "tiny-lr": "^0.1.5",


### PR DESCRIPTION
This stops the warning messages about `lodash` and `graceful-fs` old versions being no longer maintained at installation:

```
npm WARN deprecated lodash@1.0.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
```