### PR TITLE
fix(livereload): Adds livereload shutdown on plugin close callback

### DIFF
--- a/src/index.es
+++ b/src/index.es
@@ -341,6 +341,9 @@ export default function(options) {
         })
 
         plugin.close = () => {
+          if (livereload){
+            livereload.close();
+          }
           if (typeof watcher === "object") {
             watcher.close()
             watcher = undefined


### PR DESCRIPTION
Current behavior is that when plugin.close is called the livereload server remains running, which means if the plugin is re-run in the same node process, livereload reports a port conflict as it hasn't stopped.
