### PR TITLE
Use consistent checkmark in liveReload log message

### DIFF
--- a/src/livereload.es
+++ b/src/livereload.es
@@ -27,7 +27,7 @@ export default function livereloadServer(options, log) {
       return log(color.red(err))
     }
 
-    log(`${color.green("✓")} Live reload server started on port: ${color.cyan(options.port)}`)
+    log(`${color.green("✔︎")} Live reload server started on port: ${color.cyan(options.port)}`)
   })
 
   return server


### PR DESCRIPTION
It was actually using an extremely similar, but not identical, checkmark symbol to the one used in the main file.
